### PR TITLE
Toggle time label between total and remaining time

### DIFF
--- a/data/io.github.diegopvlk.Cine.gschema.xml
+++ b/data/io.github.diegopvlk.Cine.gschema.xml
@@ -28,5 +28,8 @@
 		<key name="subtitle-color" type="s">
 			<default>"#ebebeb"</default>
 		</key>
+	  <key name="show-remaining-time" type="b">
+      <default>false</default>
+    </key>
 	</schema>
 </schemalist>


### PR DESCRIPTION
Make the total time label clickable to toggle between the total time and the remaining time in a video file.