### PR TITLE
Prioritize filename over media metadata in window title

### DIFF
--- a/src/window.py
+++ b/src/window.py
@@ -1301,14 +1301,14 @@ class CineWindow(Adw.ApplicationWindow):
         @self.mpv.property_observer("media-title")
         def on_title_change(_name, title):
             def set():
-                if title == self.mpv.filename:
-                    title_no_ext = os.path.splitext(title)[0]
+                filename = self.mpv.filename
+                if filename:
+                    title_no_ext = os.path.splitext(filename)[0]
                     self.set_title(title_no_ext)
-                else:
+                elif title:
                     self.set_title(title)
 
-            if title:
-                GLib.idle_add(set)
+            GLib.idle_add(set)
 
         @self.mpv.property_observer("mute")
         def on_mute_change(_name, value):


### PR DESCRIPTION
## Overview
This pull request modifies the window title logic to prioritize the actual filename (with extension removed) over internal media metadata.

## Problem
Currently, the application displays the `media-title` property from `mpv` if it exists. Many files from the web or specific encoders include metadata titles that contain URLs or promotional text (e.g., "YTS.MX"), which clutters the interface and provides less utility than the filename itself.

## Solution
Modified the on_title_change to:
1. Check for the filename first.
2. If present, strip the extension and set as title.
3. Fall back to the metadata title only if no filename is available.

## Changes
- **src/window.py**: Updated `on_title_change` logic.

```python
@self.mpv.property_observer("media-title")
def on_title_change(_name, title):
    def set():
        filename = self.mpv.filename
        if filename:
            title_no_ext = os.path.splitext(filename)[0]
            self.set_title(title_no_ext)
        elif title:
            self.set_title(title)

    GLib.idle_add(set)