### PR TITLE
feat: Improve "Hold for Speed" functionality. Hopefully this is more 'mergable' than my last attempt at showing filenames! 😉"

### DIFF
--- a/data/io.github.diegopvlk.Cine.gschema.xml
+++ b/data/io.github.diegopvlk.Cine.gschema.xml
@@ -34,5 +34,8 @@
 		<key name="show-remaining" type="b">
 			<default>false</default>
 		</key>
+		<key name="hold-speed" type="d">
+			<default>2.0</default>
+		</key>
 	</schema>
 </schemalist>

--- a/src/options.py
+++ b/src/options.py
@@ -44,6 +44,7 @@ class OptionsMenuButton(Gtk.MenuButton):
     sub_delay_spin: Gtk.SpinButton = Gtk.Template.Child()
     audio_delay_spin: Gtk.SpinButton = Gtk.Template.Child()
     speed_spin: Gtk.SpinButton = Gtk.Template.Child()
+    hold_speed_spin: Gtk.SpinButton = Gtk.Template.Child()
 
     def __init__(self, **kwargs):
         super().__init__(**kwargs)
@@ -65,6 +66,7 @@ class OptionsMenuButton(Gtk.MenuButton):
             self.sub_delay_spin,
             self.audio_delay_spin,
             self.speed_spin,
+            self.hold_speed_spin,
         ]:
             spin_text = cast(Gtk.Text, spin.get_first_child())
             spin_down = cast(Gtk.Button, spin_text.get_next_sibling())
@@ -127,6 +129,7 @@ class OptionsMenuButton(Gtk.MenuButton):
         set_open_val(self.sub_delay_spin, float(self.win.mpv["sub-delay"] or 0))
         set_open_val(self.audio_delay_spin, float(self.win.mpv["audio-delay"] or 0))
         set_open_val(self.speed_spin, float(self.win.mpv["speed"] or 1.0))
+        set_open_val(self.hold_speed_spin, self.win._hold_speed_value)
 
     @Gtk.Template.Callback()
     def _on_reset_all_options(self, _btn):
@@ -142,6 +145,7 @@ class OptionsMenuButton(Gtk.MenuButton):
         self.sub_delay_spin.set_value(0)
         self.audio_delay_spin.set_value(0)
         self.speed_spin.set_value(1.0)
+        self.hold_speed_spin.set_value(2.0)
 
     @Gtk.Template.Callback()
     def _on_aspect_changed(self, dropdown, *arg):
@@ -264,3 +268,14 @@ class OptionsMenuButton(Gtk.MenuButton):
     @Gtk.Template.Callback()
     def _on_speed_reset(self, _btn):
         self.speed_spin.set_value(1.0)
+
+    # --- HOLD SPEED ---
+    @Gtk.Template.Callback()
+    def _on_hold_speed_changed(self, spin):
+        val = spin.get_value()
+        self.win._hold_speed_value = val
+        settings.set_double("hold-speed", val)
+
+    @Gtk.Template.Callback()
+    def _on_hold_speed_reset(self, _btn):
+        self.hold_speed_spin.set_value(2.0)

--- a/src/window.py
+++ b/src/window.py
@@ -143,6 +143,7 @@ class CineWindow(Adw.ApplicationWindow):
         self.click_hold_id: int = 0
         self.click_holding = False
         self.prev_speed: float = 1.0
+        self._hold_speed_value: float = settings.get_double("hold-speed")
         self.hide_icon_indicator: bool = True
 
         self.mpv_ctx: mpv.MpvRenderContext
@@ -1043,7 +1044,7 @@ class CineWindow(Adw.ApplicationWindow):
             try:
                 self.click_holding = True
                 self.prev_speed = cast(float, self.mpv["speed"])
-                new_speed = self.prev_speed * 2
+                new_speed = self._hold_speed_value
                 self.mpv["speed"] = new_speed
                 self.mpv.show_text(f"{new_speed:g}× ⯈⯈", "100000000")
                 self.mpv.keypress(button)

--- a/src/window.py
+++ b/src/window.py
@@ -1087,7 +1087,7 @@ class CineWindow(Adw.ApplicationWindow):
         if self.click_holding:
             self.mpv["speed"] = self.prev_speed
             self.click_holding = False
-            self.mpv.show_text(f"{self.mpv['speed']:g}×")
+            self.mpv.show_text(f"{self.mpv['speed']:g}X")
 
     def _start_hold_speed(self):
         if self.click_holding:
@@ -1098,7 +1098,7 @@ class CineWindow(Adw.ApplicationWindow):
             self.prev_speed = cast(float, self.mpv["speed"])
             new_speed = self._hold_speed_value
             self.mpv["speed"] = new_speed
-            self.mpv.show_text(f"{new_speed:g}× ⯈⯈", "100000000")
+            self.mpv.show_text(f"{new_speed:g}X ⯈⯈", "100000000")
         except mpv.ShutdownError:
             pass
 


### PR DESCRIPTION
## Description
This PR improve the **Hold for Speed** feature, allowing users to configure the hold speed (left click) or the backslash (`\`) / pipe (`|`) keys on the video area.

### Features
- **Configurable Hold Speed**: Added a new setting in the Options menu to control the target speed multiplier (ranges from 1.25x to 10x, default is 2x).
- **Persistent Setting**: The hold speed value is saved and restored using GSettings.
- **Keybind Support**: Hold the `\` key (backslash) or `|` (Shift + backslash) to temporarily speed up.

## Changes

- Added a new "Hold Speed" section to the options popover.
- Implemented a `SpinButton` to adjust the hold speed value.

<img width="432" height="716" alt="image" src="https://github.com/user-attachments/assets/d34fd6f6-393b-4c3b-a502-c0f8102d296b" />

