### PR TITLE
chore: handle error of update_translations.sh

### DIFF
--- a/update_translations.sh
+++ b/update_translations.sh
@@ -10,23 +10,24 @@ grep '\.blp$' po/POTFILES.in > /tmp/POTFILES_CINE.blp
 
 # create pot
 xgettext --files-from=/tmp/POTFILES_CINE \
-         --output="$OUTPUT" --package-name="$PACKAGE_NAME" \
-         --from-code="$ENCODING" --add-comments \
-         --keyword=_ --keyword=C_:1c,2
+	--output="$OUTPUT" --package-name="$PACKAGE_NAME" \
+	--from-code="$ENCODING" --add-comments \
+	--keyword=_ --keyword=C_:1c,2
 
 # join pot
 xgettext --files-from=/tmp/POTFILES_CINE.blp \
-         --output="$OUTPUT" --package-name="$PACKAGE_NAME" \
-         --from-code="$ENCODING" --add-comments \
-         --keyword=_ --keyword=C_:1c,2 \
-         $LANGUAGE_BLP \
-         --join-existing
+	--output="$OUTPUT" --package-name="$PACKAGE_NAME" \
+	--from-code="$ENCODING" --add-comments \
+	--keyword=_ --keyword=C_:1c,2 \
+	$LANGUAGE_BLP \
+	--join-existing
 
 
 rm /tmp/POTFILES_CINE /tmp/POTFILES_CINE.blp
 
 sed -i 's/charset=CHARSET/charset=UTF-8/g' $OUTPUT
 
-grep '^' "$LINGUAS_FILE" | while read -r lang_file; do
-    msgmerge --previous --backup=none --update "po/${lang_file}.po" "$OUTPUT"
+grep -v '^#' "$LINGUAS_FILE" | while read -r lang_file; do
+    msgmerge --previous --backup=none --update "po/${lang_file}.po" "$OUTPUT" \
+    || echo "Error with : $lang_file" >&2
 done


### PR DESCRIPTION
Hi! 

French translator here.

I just passed by to check if there was any update on the strings.

Being also a translator on Bazaar, old habits die hard, and I tried generating new strings with the bash script. However, it was broken due to a mistake with the filter (it tried to process the comment).

I also made it handle errors just in case.

I saw you moved to Weblate, so I don't know if this script remains useful (it also rearranges the strings differently than Weblate).

But hey! At least it's updated :D

Have a nice day,
Mimolet